### PR TITLE
RFC3986 required by ONVIF

### DIFF
--- a/wsdiscovery-lib/src/main/java/com/ms/wsdiscovery/servicedirectory/matcher/MatchBy.java
+++ b/wsdiscovery-lib/src/main/java/com/ms/wsdiscovery/servicedirectory/matcher/MatchBy.java
@@ -53,6 +53,30 @@ public enum MatchBy {
      */
     RFC2396("http://schemas.xmlsoap.org/ws/2005/04/discovery/rfc2396", new MatchScopeRFC2396()),
     /**
+     * From the OASIS WS-Discovery Specification Version 1.1:
+     * Using a case-insensitive comparison,
+     * <li>The scheme of S1 and S2 is the same and</li>
+     * <li>The authority of S1 and S2 is the same and</li>
+     * <p>
+     * Sheme-Based Normalization (refer to RFC3986 for description)
+     * <p>
+     * Using a case-sensitive comparison,
+     * <li>The percent decoded normalized path_segments of S1 is a
+     *      segment-wise (not string) prefix of the percent decoded
+     *      normalized path_segments of S2</li>
+     * All other components (e.g., query and fragment) are explicitly excluded from comparision.
+     * <p>
+     * Note: this matching rule does NOT test whether the string representation of S1 is
+     * a prefix of the string representation of S2. For example,
+     * "http://example.com/abc" matches "http://example.com/abc/def" using this rule
+     * but "http://example.com/a" does not.
+     * <p>
+     * Note: although this is a requirement for WS-Disovery 1.1, it is included
+     * to support the ONVIF Specification which requires the WS-Discovery Draft
+     * (pre 1.0) but supersedes the RFC2396 requirement with RFC3986.
+     */
+    RFC3986("http://schemas.xmlsoap.org/ws/2005/04/discovery/rfc3986", new MatchScopeRFC3986()),
+    /**
      * From the WS-Discovery Specification Draft, 2005:<p>
      * Using a case-insensitive comparison, the scheme of S1 and S2 is "uuid" and each of the 
      * unsigned integer fields in S1 is equal to the corresponding field in S2, or equivalently, the 

--- a/wsdiscovery-lib/src/main/java/com/ms/wsdiscovery/servicedirectory/matcher/MatchScopeRFC3986.java
+++ b/wsdiscovery-lib/src/main/java/com/ms/wsdiscovery/servicedirectory/matcher/MatchScopeRFC3986.java
@@ -1,0 +1,140 @@
+/*
+MatchScopeRFC2396.java
+
+Copyright (C) 2008-2009 Magnus Skjegstad
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+package com.ms.wsdiscovery.servicedirectory.matcher;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLDecoder;
+import java.util.ArrayList;
+
+import com.ms.wsdiscovery.servicedirectory.WsDiscoveryService;
+import com.ms.wsdiscovery.xml.jaxb_generated.ScopesType;
+
+/**
+ * Match scope against target service using the RFC3986 algorithm.
+ * See the WS-Discovery specification or {@link MatchBy} for details.
+ * @author Steven Dillingham
+ */
+public class MatchScopeRFC3986 implements IMatchScope {
+
+    /**
+     * Match scope against target service using the RFC3986 algorithm.
+     * See the WS-Discovery specification or {@link MatchBy} for details.
+     * @param target Target service.
+     * @param probeScopes Scopes to probe for.
+     * @return True on success, false on failure.
+     */
+    public boolean matchScope(WsDiscoveryService target, ScopesType probeScopes) {
+        // All scopes in probe must match target
+        if (probeScopes != null)
+            for (String probescope : probeScopes.getValue()) {
+                boolean match = false;
+                URI probeuri = URI.create(probescope);
+
+                // Loop through scopes in target to find a match
+                for (URI targetscope : target.getScopes())
+                    if (matchURIByRFC3986(targetscope, probeuri)) {
+                        match = true;
+                        break;
+                    }
+
+                // No match found for this probe scope, return false
+                if (!match)
+                    return false;
+            }
+
+        // All scopes in probe matched
+        return true;
+    }
+
+    /**
+     * Helper for {@link MatchScopeRFC3986#matchURIByRFC3986(java.net.URI, java.net.URI)}. Matches
+     * a scope in the target service against a scope in the probe.
+     * @param target Target service scope URI.
+     * @param probe Probe scope URI.
+     * @return True on success, false on failure.
+     */
+    protected boolean matchURIByRFC3986(URI target, URI probe) {
+        // See WsDiscovery, section 5.1 for details
+        if (((target != null) && (probe != null)) && // Fail if one or both of the parameters are null
+                ((target.getScheme() != null) && (probe.getScheme() != null)) && // Fail if the scheme is not set
+                (target.getScheme().toUpperCase().equals(probe.getScheme().toUpperCase()))) // Compare scheme
+            if (target.getAuthority().toUpperCase().equals(probe.getAuthority().toUpperCase())) { // Compare server (authority)
+                String[] targetsegments = normalizeUriPath(target.getPath());// target.getPath().split("/"); // Split path into segments
+                String[] probesegments = normalizeUriPath(probe.getPath());// probe.getPath().split("/");
+
+                if (probesegments.length <= targetsegments.length) { // If probe has more segments than target, a match is not possible
+                    for (int i = 0; i < probesegments.length; i++) // Check if each segment in probe matches a segment in target
+                        if (!probesegments[i].equals(targetsegments[i]))
+                            return false;
+                    // I.e http://example.com/abc matches http://example.com/abc/def,
+                    // but http://example.com/a does not.
+                } else
+                    return false;
+
+                // If we get here, all tests are ok - return true
+                return true;
+            }
+
+        return false;
+    }
+
+    /**
+     * Helper for {@link MatchScopeRFC3986#normalizeUriPath(String)}. Normalized the
+     * path according to RFC3986 (Percent-Encoding & Path Segment).
+     * @param path The Path of a {@link URI}.
+     * @return String array of the normalized path.
+     */
+    protected String [] normalizeUriPath(String path) {
+
+        String[] retVal;
+
+        try {
+            // Percent-Encoding normalization
+            retVal = URLDecoder.decode(path, "UTF-8").split("/");
+        } catch (UnsupportedEncodingException e) {
+            retVal = path.toLowerCase().split("/");
+        }
+
+        ArrayList<String> normalizedSegments = new ArrayList<String>();
+
+        // Loop through and deal with Path normalization
+        for (String segment : retVal) {
+
+            // Ignore the 'current path' segment
+            if (segment.equals(".") == false) {
+
+                // Handle the 'parent path' segment
+                if (segment.equals("..")) {
+                    // Remove the last segment if one is present
+                    if (normalizedSegments.size() > 0) {
+                        normalizedSegments.remove(normalizedSegments.size() - 1);
+                    }
+                } else {
+                    normalizedSegments.add(segment);
+                }
+            }
+
+        }
+
+        retVal = new String[normalizedSegments.size()];
+        retVal = normalizedSegments.toArray(retVal);
+        return retVal;
+    }
+}

--- a/wsdiscovery-lib/src/test/java/com/ms/wsdiscovery/servicedirectory/matcher/MatchScopeRFC3986Test.java
+++ b/wsdiscovery-lib/src/test/java/com/ms/wsdiscovery/servicedirectory/matcher/MatchScopeRFC3986Test.java
@@ -49,7 +49,7 @@ public class MatchScopeRFC3986Test {
     }
 
     /**
-     * Test of matchScope method, of class MatchScopeRFC2396.
+     * Test of matchScope method, of class MatchScopeRFC3986.
      */
     @Test
     public void testMatchScope() {
@@ -74,11 +74,11 @@ public class MatchScopeRFC3986Test {
     }
 
     /**
-     * Test of matchURIByRFC2396 method, of class MatchScopeRFC2396.
+     * Test of matchURIByRFC3986 method, of class MatchScopeRFC3986.
      */
     @Test
     public void testMatchURIByRFC3986() throws URISyntaxException {
-        System.out.println("matchURIByRFC2396");
+        System.out.println("matchURIByRFC3986");
 
         URI target = new URI("http://www.examples.com/a/b");
         URI probe = new URI("http://www.examples.com/a/b");

--- a/wsdiscovery-lib/src/test/java/com/ms/wsdiscovery/servicedirectory/matcher/MatchScopeRFC3986Test.java
+++ b/wsdiscovery-lib/src/test/java/com/ms/wsdiscovery/servicedirectory/matcher/MatchScopeRFC3986Test.java
@@ -1,0 +1,127 @@
+package com.ms.wsdiscovery.servicedirectory.matcher;
+
+import com.ms.wsdiscovery.WsDiscoveryBuilder;
+import com.ms.wsdiscovery.servicedirectory.WsDiscoveryService;
+import com.ms.wsdiscovery.xml.jaxb_generated.ScopesType;
+import java.net.URI;
+import java.net.URISyntaxException;
+import javax.xml.namespace.QName;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+/**
+ * @uthor Steven Dillingham
+ */
+public class MatchScopeRFC3986Test {
+
+    private WsDiscoveryService service;
+    private QName servicePortType;
+    private String serviceScope;
+    private String serviceXAddr;
+    private MatchScopeRFC3986 instance;
+
+    public MatchScopeRFC3986Test() {
+    }
+
+    @BeforeClass
+    public static void setUpClass() throws Exception {
+    }
+
+    @AfterClass
+    public static void tearDownClass() throws Exception {
+    }
+
+    @Before
+    public void setUp() {
+        instance = new MatchScopeRFC3986();
+        servicePortType = new QName("http://localhost/portType", "localPart", "ns");
+        serviceScope = "onvif://www.onvif.org/Profile/Q/Operational";
+        serviceXAddr = "http://10.0.0.1:1234/localPart";
+        service = WsDiscoveryBuilder.createService(servicePortType, serviceScope, serviceXAddr);
+    }
+
+    @After
+    public void tearDown() {
+    }
+
+    /**
+     * Test of matchScope method, of class MatchScopeRFC2396.
+     */
+    @Test
+    public void testMatchScope() {
+        System.out.println("matchScope");
+        ScopesType probeScopes = new ScopesType();
+
+        probeScopes.getValue().add("ONVIF://www.onvif.org/Profile/Q/");
+        probeScopes.getValue().add("onvif://www.ONVIF.org/Profile/Q/Operational");
+        probeScopes.getValue().add("onvif://www.onvif.org/Pr%6Ffile/Q/%4fperational");
+        probeScopes.getValue().add("onvif://www.onvif.org/Pr%6ffile/Q/%4Fperational");
+        probeScopes.getValue().add("onvif://www.onvif.org/Profile/S/../Q/Operational");
+        probeScopes.getValue().add("onvif://www.onvif.org/Profile/./Q/Operational");
+
+        boolean expResult = true;
+        boolean result = instance.matchScope(service, probeScopes);
+        assertEquals(expResult, result);
+
+        probeScopes.getValue().add("onvif://www.onvif.org/PROFILE/Q/");
+        expResult = false;
+        result = instance.matchScope(service, probeScopes);
+        assertEquals(expResult, result);
+    }
+
+    /**
+     * Test of matchURIByRFC2396 method, of class MatchScopeRFC2396.
+     */
+    @Test
+    public void testMatchURIByRFC3986() throws URISyntaxException {
+        System.out.println("matchURIByRFC2396");
+
+        URI target = new URI("http://www.examples.com/a/b");
+        URI probe = new URI("http://www.examples.com/a/b");
+        MatchScopeRFC3986 instance = new MatchScopeRFC3986();
+        boolean expResult = true;
+        boolean result = instance.matchURIByRFC3986(target, probe);
+        assertEquals(expResult, result);
+
+        target = new URI("http://www.examples.com/a/b");
+        probe = new URI("http://www.examples.com/a/b///");
+        instance = new MatchScopeRFC3986();
+        expResult = true;
+        result = instance.matchURIByRFC3986(target, probe);
+        assertEquals(expResult, result);
+
+        target = new URI("http://www.examples.com/a/b");
+        probe = new URI("http://www.examples.com/a/");
+        instance = new MatchScopeRFC3986();
+        expResult = true;
+        result = instance.matchURIByRFC3986(target, probe);
+        assertEquals(expResult, result);
+
+        target = new URI("http://www.examples.com/a/b");
+        probe = new URI("http://www.examples.com/aa");
+        instance = new MatchScopeRFC3986();
+        expResult = false;
+        result = instance.matchURIByRFC3986(target, probe);
+        assertEquals(expResult, result);
+
+        target = new URI("http://www.a.com");
+        probe = new URI("http://www.b.com");
+        instance = new MatchScopeRFC3986();
+        expResult = false;
+        result = instance.matchURIByRFC3986(target, probe);
+        assertEquals(expResult, result);
+
+        target = new URI("http://www.examples.com/a/b");
+        probe = new URI("http://www.examples.com/a/b/c/");
+        instance = new MatchScopeRFC3986();
+        expResult = false;
+        result = instance.matchURIByRFC3986(target, probe);
+        assertEquals(expResult, result);
+
+    }
+
+}


### PR DESCRIPTION
The WS-Discovery Draft and 1.0 specified RFC2396 for URI matching. ONVIF requires support for RFC3986 which supersedes RFC2396. 

RFC3986 added additional normalization for case insensitive percent encoding in the URI's path and path segment normalization (i.e. '.' and '..') which have been implemented.

RFC3986 all added schema normalization which normalizes the URIs 'http://www.onvif.org/device' and 'http://www.onvif.org:80/device' to be equivalent. This has not been implemented because there is quite a bit more to understand for normalizing different schemas that have their own specifications.

Output from test run
Running com.ms.wsdiscovery.servicedirectory.matcher.MatchScopeRFC3986Test
matchScope
matchURIByRFC3986
Tests run: 2, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.023 sec

